### PR TITLE
feat: completion & run support for Kotlin & Groovy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@
 All notable changes to the **JBang** extension will be documented in this file.
 
 ## [0.4.0]  TBD
-- Add completion for `//NATIVE_OPTIONS`, `//COMPILE_OPTIONS`, `//RUNTIME_OPTIONS`
+- Add completion for `//NATIVE_OPTIONS`, `//COMPILE_OPTIONS`, `//RUNTIME_OPTIONS`, `//GROOVY`, `//KOTLIN`
 - Report invalid `//JAVA` version at the proper location
+- Provide dependency completion for Kotlin and Groovy files
+- Display `Run JBang` codelens for Kotlin and Groovy files
 
 ## [0.3.0]  29/10/2022
 - Automagically configures JBang-managed JDKs, i.e. no need to configure `java.configuration.runtimes`.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License](https://img.shields.io/github/license/jbangdev/jbang-vscode?style=for-the-badge)](https://github.com/jbangdev/jbang-vscode/blob/main/LICENSE)
 
 # JBang for Visual Studio Code
-This is an early work-in-progress extension for [vscode-java](https://marketplace.visualstudio.com/items?itemName=redhat.java). It aims at providing support for the [JBang](https://www.jbang.dev/) scripts written in Java.
+This is an early work-in-progress extension for [vscode-java](https://marketplace.visualstudio.com/items?itemName=redhat.java). It aims at providing support for the [JBang](https://www.jbang.dev/) scripts written in Java (and partial support for Kotlin and Groovy).
 
 **Pre-requisites:**
 - [JBang](https://www.jbang.dev/download/) is installed and available in the PATH. Alternatively, you can set the `jbang.home` preference to point to a `JBang` installation
@@ -29,6 +29,7 @@ This is an early work-in-progress extension for [vscode-java](https://marketplac
 - Partial support for `build.jbang` files: If a folder containing `build.jbang` is opened, it'll be used to configure the Java settings of its //SOURCES. Currently, changes in `build.jbang` require manually triggering the `JBang > Synchronize JBang` command (via codelens or context menu) to take effect.
 - Export the script as a native binary, by right-clicking on the script and selecting the `JBang > Export as native binary` menu. This requires GraalVM to be installed with the native-image extension. See https://www.jbang.dev/documentation/guide/latest/usage.html#build-and-run-native-image-experimental
 - Automagically configures JBang-managed JDKs, i.e. no need to configure `java.configuration.runtimes`.
+- Partial support for Kotlin and Groovy scripts: completion for directive and run command are available, but no classpath management when editing the files.
 
 ## Preferences
 - `jbang.home`: Specifies the folder path to the JBang directory (not the executable), eg. `~/.sdkman/candidates/jbang/current`. On Windows, backslashes must be escaped, eg `C:\\ProgramData\\chocolatey\\lib\\jbang`. Used by the `JBang: Create a new script` wizard and the `Run JBang` code lens. Useful in case `jbang` is not automatically picked up from the $PATH, for some reason.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
 	],
 	"activationEvents": [
 		"onLanguage:java",
+		"onLanguage:jbang",
+		"onLanguage:groovy",
+		"onLanguage:kotlin",
 		"onCommand:jbang.script.generate",
 		"workspaceContains:build.jbang"
 	],

--- a/src/CompletionProvider.ts
+++ b/src/CompletionProvider.ts
@@ -5,13 +5,14 @@ import { DirectivesCompletion } from "./completion/DirectivesCompletion";
 import { JavaOptionsCompletion } from "./completion/JavaOptionsCompletion";
 import { SourcesCompletion } from "./completion/SourcesCompletion";
 import DocumentationProvider from "./DocumentationProvider";
+import { SUPPORTED_LANGUAGES } from "./JBangUtils";
 
 export class JBangCompletionProvider implements CompletionItemProvider<CompletionItem> {
 
     private completionParticipants: CompletionParticipant[] = [];
 
     async provideCompletionItems(document: TextDocument, position: Position, token: CancellationToken, context: CompletionContext): Promise<CompletionList|JBangCompletionItem[]> {
-        if (document.languageId !== 'java' && document.languageId !== 'jbang') {
+        if (!SUPPORTED_LANGUAGES.includes(document.languageId)) {
             return [];
         }
         const line = document.lineAt(position);
@@ -41,7 +42,7 @@ export class JBangCompletionProvider implements CompletionItemProvider<Completio
             new JavaOptionsCompletion(),
             new DirectivesCompletion()
         ];
-        ["jbang", "java"].forEach(languageId => {
+        SUPPORTED_LANGUAGES.forEach(languageId => {
             context.subscriptions.push(
                 languages.registerCompletionItemProvider(languageId, this, ":", "/", "-")
             );

--- a/src/EditorListener.ts
+++ b/src/EditorListener.ts
@@ -1,5 +1,5 @@
 import { commands, ExtensionContext, TextEditor, window } from "vscode";
-import { isJBangFile } from "./JBangUtils";
+import { isJBangFile, SUPPORTED_LANGUAGES } from "./JBangUtils";
 
 export class EditorListener {
     public async initialize(context: ExtensionContext): Promise<void> {
@@ -14,14 +14,14 @@ export class EditorListener {
 
     checkJBangFileContext(editor?: TextEditor) {
         //If not a java file, we bail
-        if (!editor || !editor.document || ("java" !== editor.document.languageId && "jbang" !== editor.document.languageId)) {
+        if (!editor || !editor.document || (!SUPPORTED_LANGUAGES.includes(editor.document.languageId ))) {
             return this.setJBangFileContext(false);
         }
         if (editor.document.fileName.endsWith("build.jbang")) {
             return this.setJBangFileContext(true);
         }
 
-        const content = editor?.document.getText();
+        const content = editor.document.getText();
         if (!content) {
             return this.setJBangFileContext(false);
         }

--- a/src/JBangHoverProvider.ts
+++ b/src/JBangHoverProvider.ts
@@ -1,6 +1,7 @@
 import { CancellationToken, ExtensionContext, Hover, HoverProvider, languages, Position, TextDocument } from "vscode";
 import { TextHelper } from "./completion/TextHelper";
 import DocumentationProvider from "./DocumentationProvider";
+import { SUPPORTED_LANGUAGES } from "./JBangUtils";
 import { Dependency } from "./models/Dependency";
 
 const DEPS = "//DEPS "
@@ -9,7 +10,7 @@ export class JBangHoverProvider implements HoverProvider {
 
     async provideHover(document: TextDocument, position: Position, token: CancellationToken): Promise<Hover|undefined> {
         
-        if (document.languageId !== 'java' && document.languageId !== 'jbang') {
+        if (SUPPORTED_LANGUAGES.includes(document.languageId)) {
             return undefined;
         }
         const line = document.lineAt(position);
@@ -26,7 +27,7 @@ export class JBangHoverProvider implements HoverProvider {
     }
 
     public initialize(context: ExtensionContext) {
-        ["jbang", "java"].forEach(languageId => {
+        SUPPORTED_LANGUAGES.forEach(languageId => {
             context.subscriptions.push(
                 languages.registerHoverProvider(languageId, this)
             );

--- a/src/JBangUtils.ts
+++ b/src/JBangUtils.ts
@@ -1,3 +1,5 @@
+export const SUPPORTED_LANGUAGES = ["java", "groovy", "kotlin", "jshell", "jbang"];
+
 export function isJBangFile(content: string | string[]): boolean {
     let lines:string[] = [];
     if (typeof content === 'string' || content instanceof String) {
@@ -8,7 +10,7 @@ export function isJBangFile(content: string | string[]): boolean {
     return lines.find(isJBangDirective) !== undefined; 
 }
 
-const KNOWN_DIRECTIVES = ["///usr/bin/env jbang ", "//DEPS ", "//JAVA ", "//GAV ", "//FILES ", "//SOURCES ", "//DESCRIPTION ", "//REPOS ", "//JAVAC_OPTIONS ", "//JAVA_OPTIONS ", "//JAVAAGENT ", "//CDS ", "//KOTLIN ", "//GROOVY ", "//MANIFEST "];
+const KNOWN_DIRECTIVES = ["///usr/bin/env jbang ", "//DEPS ", "//JAVA ", "//GAV ", "//FILES ", "//SOURCES ", "//DESCRIPTION ", "//REPOS ", "//JAVAC_OPTIONS ", "//JAVA_OPTIONS ", "//JAVAAGENT ", "//CDS ", "//KOTLIN ", "//GROOVY ", "//MANIFEST", "//RUNTIME_OPTIONS", "//COMPILE_OPTIONS", "//NATIVE_OPTIONS"];
 
 export function isJBangDirective(line: string): boolean {
     //TODO: detect @Grab/@Grape 

--- a/src/completion/DirectivesCompletion.ts
+++ b/src/completion/DirectivesCompletion.ts
@@ -14,6 +14,8 @@ const CDS = "//CDS ";
 const GAV = "//GAV ";
 const DESCRIPTION = "//DESCRIPTION ";
 const JAVAAGENT = "//JAVAAGENT "; 
+const GROOVY = "//GROOVY ";
+const KOTLIN = "//KOTLIN ";
 
 export class DirectivesCompletion implements CompletionParticipant {
 
@@ -39,6 +41,13 @@ export class DirectivesCompletion implements CompletionParticipant {
         }
         items.push(getCompletion("//DEPS", "Add JBang dependencies", range));
         
+        if (document.languageId === 'groovy' && !scanner.found(GROOVY)) {
+            items.push(getCompletion(GROOVY, "Groovy version to use", range));
+        }
+        if (document.languageId === 'kotlin' && !scanner.found(KOTLIN)) {
+            items.push(getCompletion(KOTLIN, "Kotlin version to use", range));
+        }
+
         if (!scanner.found(GAV)) {
             items.push(getCompletion(GAV, "Set Group, Artifact and Version", range));
         }
@@ -92,7 +101,7 @@ class DirectiveScanner {
 
     scan(document: TextDocument) {
         const checkedDirectives = [
-            JAVA, JAVAC_OPTIONS, COMPILE_OPTIONS, DESCRIPTION, CDS, GAV, JAVAAGENT, MANIFEST, JAVA_OPTIONS, RUNTIME_OPTIONS, NATIVE_OPTIONS
+            JAVA, JAVAC_OPTIONS, COMPILE_OPTIONS, DESCRIPTION, CDS, GAV, JAVAAGENT, MANIFEST, JAVA_OPTIONS, RUNTIME_OPTIONS, NATIVE_OPTIONS, KOTLIN, GROOVY
         ]
         const lines = document.getText().split(/\r?\n/);
         for (let i = 0; i < lines.length && checkedDirectives.length > 0; i++) {
@@ -120,6 +129,7 @@ function getCompletion(directive: string, detail: string, range?: Range, command
     item.insertText = new SnippetString(directive.trim() + " ${0}");
     item.range = range;
     item.command = command;
+    item.detail = detail;
     return item;
 }
 


### PR DESCRIPTION
- Completion available for Kotlin and Groovy files
- Display `Run JBang` codelens

There's no classpath management though, Groovy/Kotlin editing support in the IDE is out of scope of this project.

https://user-images.githubusercontent.com/148698/203766648-fc861aaa-3523-43cb-8e44-c33b2474c07a.mp4

