### PR TITLE
fix: ensure commands can run from command palette

### DIFF
--- a/src/JBangDebugger.ts
+++ b/src/JBangDebugger.ts
@@ -1,28 +1,26 @@
-import { commands, debug, DebugConfiguration, ExtensionContext, tasks, Uri, window, workspace } from "vscode";
+import { commands, debug, DebugConfiguration, ExtensionContext, tasks, Uri, workspace } from "vscode";
 import { JBangTaskProvider } from "./JBangTaskProvider";
+import { handleCommand } from "./utils/commandHelper";
 
 export const DEBUG_WITH_JBANG_COMMAND_ID = 'jbang.script.debug';
 
 export class JBangDebugger {
 
     initialize(_context: ExtensionContext) {
-
         tasks.registerTaskProvider('jbang', new JBangTaskProvider());
+        commands.registerCommand(DEBUG_WITH_JBANG_COMMAND_ID, handleCommand.bind(this, this.debug));
+    }
 
-        commands.registerCommand(DEBUG_WITH_JBANG_COMMAND_ID, async (uri: Uri) => {
-            if (uri !== undefined) {
-                await window.showTextDocument(uri);
-            }
-            const debugConfiguration: DebugConfiguration = {
-                name: 'Start JBang Application and debug',
-                type: 'java',
-                request: 'attach',
-                hostName: "localhost",
-                port: 4004,
-                preLaunchTask: `jbang: ${JBangTaskProvider.labelProvidedTask}`
-            };
-            await debug.startDebugging(workspace.workspaceFolders ? workspace.workspaceFolders[0] : undefined, debugConfiguration);
-        });
+    private async debug(uri: Uri) {
+        const debugConfiguration: DebugConfiguration = {
+            name: 'Start JBang Application and debug',
+            type: 'java',
+            request: 'attach',
+            hostName: "localhost",
+            port: 4004,
+            preLaunchTask: `jbang: ${JBangTaskProvider.labelProvidedTask}`
+        };
+        await debug.startDebugging(workspace.workspaceFolders ? workspace.workspaceFolders[0] : undefined, debugConfiguration);
     }
 
 }

--- a/src/utils/commandHelper.ts
+++ b/src/utils/commandHelper.ts
@@ -1,0 +1,24 @@
+import { Uri, window } from "vscode";
+import { isJBangFile } from "../JBangUtils";
+
+export async function handleCommand(callback: (uri: Uri) => Promise<any>, uri: any) {
+  const scriptUri = getValidScriptUri(uri);
+  if (scriptUri) {
+      return callback(scriptUri);
+  }
+  showErrorMessage();
+}
+
+export function getValidScriptUri(uri ?: Uri): Uri | undefined {
+  if (uri) {
+      return uri;
+  }
+  const activeEditor = window.activeTextEditor;
+  if (activeEditor && activeEditor.document && isJBangFile(activeEditor.document.getText())) {
+      return activeEditor.document.uri;
+  }
+}
+
+export function showErrorMessage() {
+  window.showErrorMessage("You must select a JBang script");
+}


### PR DESCRIPTION
Ensure commands can run from palette by passing URI of opened document to JBang commands.

Fixes #78 