### PR TITLE
feat: Trying some TextMate Grammar for JBang directives

### DIFF
--- a/language-support/build.jbang.tmLanguage.json
+++ b/language-support/build.jbang.tmLanguage.json
@@ -1,11 +1,13 @@
 {
-    "name": "JBang",
-    "scopeName": "source.jbang",
+    "name": "Build JBang",
+    "scopeName": "source.build.jbang",
     "patterns": [
       {
         "comment": "source.java is defined in https://github.com/microsoft/vscode/blob/main/extensions/java/syntaxes/java.tmLanguage.json",
         "include": "source.java"
+      },
+      {
+        "include": "inline.jbang"
       }
-    ],
-    "uuid": "b67884ea-cc0a-4f99-b680-7ee7c3bb04d8"
+    ]
   }

--- a/language-support/inline-jbang.tmLanguage.json
+++ b/language-support/inline-jbang.tmLanguage.json
@@ -1,0 +1,25 @@
+{
+  "name": "jbang",
+  "scopeName": "inline.jbang",
+  "injectionSelector": "L:source.java -comment -string",
+  "patterns": [
+    {
+      "contentName": "meta.embedded.block.jbang",
+      "match": "^(//)(DEPS|JAVA|MAIN|FILES|SOURCES|PREVIEW|MODULE|DESCRIPTION|GAV|COMPILE_OPTIONS|JAVAC_OPTIONS|RUNTIME_OPTIONS|JAVA_OPTIONS|NATIVE_OPTIONS|REPOS|MANIFEST|CDS|KOTLIN|GROOVY|JAVAAGENT)\\s+(.*)$",
+      "captures": {
+        "0":{
+          "name":"directive.jbang"
+        },
+        "1":{
+          "name":"comment.line.double-slash.java"
+        },
+        "2": {
+          "name": "keyword.directive.jbang"
+        },
+        "3": {
+          "name": "string.directive.jbang"
+        }
+      }
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -48,8 +48,18 @@
 		"grammars": [
 			{
 				"language": "jbang",
-				"scopeName": "source.jbang",
-				"path": "./language-support/jbang.tmLanguage.json"
+				"scopeName": "source.build.jbang",
+				"path": "./language-support/build.jbang.tmLanguage.json"
+			},
+			{
+				"injectTo": [
+					"source.java"
+				],
+				"scopeName": "inline.jbang",
+				"path": "./language-support/inline-jbang.tmLanguage.json",
+				"embeddedLanguages": {
+					"meta.embedded.block.jbang": "jbang"
+				}
 			}
 		],
 		"javaExtensions": [


### PR DESCRIPTION
I have no idea what I'm doing. It's most likely wrong, certainly suboptimal, but looks half decent in java files
Can't figure out how to enable it properly in build.jbang files though.


<img width="1321" alt="Screenshot 2024-02-17 at 17 10 15" src="https://github.com/jbangdev/jbang-vscode/assets/148698/c487cbea-7be0-431f-9cab-2c4027346c07">
<img width="928" alt="Screenshot 2024-02-17 at 17 11 01" src="https://github.com/jbangdev/jbang-vscode/assets/148698/75d0c94c-34e3-48cd-8713-f045bfef54ae">


@maxandersen WDYT?